### PR TITLE
(hybris) let the linker decide what LD_LIBRARY_PATH should be. JB#41777

### DIFF
--- a/rootdir/init.common.srv-legacy.rc
+++ b/rootdir/init.common.srv-legacy.rc
@@ -72,7 +72,6 @@ service qcamerasvr /system/vendor/bin/mm-qcamera-daemon
     user camera
     group camera system inet input graphics
     writepid /dev/cpuset/camera-daemon/tasks
-    setenv LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib
 
 # QCOM prop
 service per_mgr /system/vendor/bin/pm-service

--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -72,7 +72,6 @@ service qcamerasvr /odm/bin/mm-qcamera-daemon
     user camera
     group camera system inet input graphics
     writepid /dev/cpuset/camera-daemon/tasks
-    setenv LD_LIBRARY_PATH /usr/libexec/droid-hybris/lib-dev-alog:/vendor/lib:/system/lib:/odm/lib
 
 # QCOM prop
 service per_mgr /odm/bin/pm-service


### PR DESCRIPTION
Revert "[64bit](hybris) Set ldlibpath for 32bit qcamerasvr. JB#37811"

This reverts commit bb839d980dd41586bf5152da90a676b01ebf972d.