### PR TITLE
sensors.rc: always start sensors (ignore encryption)

### DIFF
--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -21,7 +21,6 @@ service sensors /odm/bin/sensors.qcom
     class late_start
     user system
     group system
-    disabled
 
 # Start the service for unecrypted devices
 on property:ro.crypto.state=unencrypted


### PR DESCRIPTION
Platforms like Sailfish OS do not have ro.crypto properties, hence
they cannot rely on the events in this .rc file.